### PR TITLE
Wasabi Hot Cloud Storage auto get url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,12 @@ You need to specify a YAML config file such as following: ::
       aws_access_key_id: mykey                  # Drivers params
       aws_secret_access_key: mysecrect
       endpoint_url: https://sos-ch-dk-2.exo.io
+
+  my_wasabi:
+      driver: wasabi
+      aws_access_key_id: <access_key>
+      aws_secret_access_key: <secret_key>
+      region_name: <region_name>
   
 In command line, ``--config-file`` and ``--config-raw`` can be used to make the
 choice, else ``~/.osb.yml``, then ``/etc/osb.yml`` will be used.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -24,7 +24,20 @@ Drivers configuration are stored as a YAML file containing one or several profil
       aws_secret_access_key: MySecret
       endpoint_url: https://sos-ch-vie-1.exo.io
 
-This file provides two profiles for an Exoscale benchmark, on in DK-2 and the other one in CH-VIE-1.
+    my_wasabi_east:
+        driver: wasabi
+        aws_access_key_id: <access_key>
+        aws_secret_access_key: <secret_key>
+        region_name: us-east-1
+
+    my_wasabi_west:
+        driver: wasabi
+        aws_access_key_id: <access_key>
+        aws_secret_access_key: <secret_key>
+        region_name: us-west-1
+
+This file provides two profiles for an Exoscale benchmark, on in DK-2 and the other one in CH-VIE-1
+as well as two profiles for Wasabi Hot Cloud Storage, one on the East Coast, USA, and the other on the West Coast, USA.
 
 File choice
 -----------


### PR DESCRIPTION
removes the requirement for endpoint_url with Wasabi driver, and only requires region_name config. also updated examples.